### PR TITLE
Fix incorrect sssd-session-recording.conf template value substitutions

### DIFF
--- a/templates/sssd-session-recording.conf
+++ b/templates/sssd-session-recording.conf
@@ -1,4 +1,4 @@
 [session_recording]
 scope={{ tlog_scope_sssd }}
-users={{ tlog_users_sssd|join(', ') }}
-groups={{ tlog_groups_sssd|join(', ') }}
+users={{ tlog_users_sssd }}
+groups={{ tlog_groups_sssd }}


### PR DESCRIPTION
When deploying with the default ansible playbook from the README
~~~
- name: Deploy session recording
  hosts: all
  roles:
    - linux-system-roles.tlog
  vars:
    tlog_scope_sssd: some
    tlog_users_sssd: recordeduser
~~~
The resulting configuration file `/etc/sssd/conf.d/sssd-session-recording.conf` is incorrect

~~~
[session_recording]
scope=some
users=r, e, c, o, r, d, e, d, u, s, e, r
groups=[]
~~~

I would also like to fix the `groups=[]` default here as `sssd-session-recording.conf` is expecting only a string value(`"" is okay`). Previously it was recommended to change this to a collection in https://github.com/linux-system-roles/tlog/commit/d5b8a4febafa43ebdbf0c2cbb90aa8297cf8039f

@richm @pcahyna Would you mind suggesting the best fix here for this?