### PR TITLE
Add exclude_users and exclude_groups support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ YAML list of groups to be recorded:
 
 - `tlog_groups_sssd` (default: `[]`)
 
+YAML list of users to be excluded from recording (only applicable when
+scope=all):
+
+- `tlog_exclude_users_sssd` (default: `[]`)
+
+YAML list of groups to be excluded from recording (only applicable when
+scope=all):
+
+- `tlog_exclude_groups_sssd` (default: `[]`)
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@ tlog_use_sssd: yes
 tlog_scope_sssd: none
 tlog_users_sssd: []
 tlog_groups_sssd: []
+tlog_exclude_users_sssd: []
+tlog_exclude_groups_sssd: []

--- a/templates/sssd-session-recording.conf
+++ b/templates/sssd-session-recording.conf
@@ -2,3 +2,5 @@
 scope={{ tlog_scope_sssd }}
 users={{ tlog_users_sssd|join(', ') }}
 groups={{ tlog_groups_sssd|join(', ') }}
+exclude_users={{ tlog_exclude_users_sssd|join(', ') }}
+exclude_groups={{ tlog_exclude_groups_sssd|join(', ') }}

--- a/tests/run_sssd_tests.yml
+++ b/tests/run_sssd_tests.yml
@@ -22,3 +22,7 @@
       - __tlog_conf_content.stdout.find('users={{ tlog_users_sssd|join(', ') }}')
       # yamllint disable-line rule:line-length
       - __tlog_conf_content.stdout.find('groups={{ tlog_groups_sssd|join(', ') }}')
+      # yamllint disable-line rule:line-length
+      - __tlog_conf_content.stdout.find('exclude_users={{ tlog_exclude_users_sssd|join(', ') }}')
+      # yamllint disable-line rule:line-length
+      - __tlog_conf_content.stdout.find('exclude_groups={{ tlog_exclude_groups_sssd|join(', ') }}')

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -13,3 +13,5 @@
         - tlog_scope_sssd
         - tlog_users_sssd
         - tlog_groups_sssd
+        - tlog_exclude_users_sssd
+        - tlog_exclude_groups_sssd

--- a/tests/tests_sssd.yml
+++ b/tests/tests_sssd.yml
@@ -33,3 +33,17 @@
 
     - name: Run sssd tests
       import_tasks: run_sssd_tests.yml
+
+    - name: Run role with excluded users and groups
+      import_role:
+        name: linux-system-roles.tlog
+      vars:
+        tlog_scope_sssd: all
+        tlog_exclude_users_sssd:
+          - jeff
+          - james
+        tlog_exclude_groups_sssd:
+          - admins
+
+    - name: Run sssd tests
+      import_tasks: run_sssd_tests.yml


### PR DESCRIPTION
This PR adds support for excluding users and groups via SSSD configuration - supported was added into SSSD upstream master here https://github.com/SSSD/sssd/issues/5089 but is not yet in a released version.

The new options are self-explanatory and work the same as **tlog_users_sssd**, and **tlog_groups_sssd** however the exclude options only apply in SSSD when `scope=all`