### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: EL
       versions:
         - 8
+        - 9
   galaxy_tags:
     - session
     - recording


### PR DESCRIPTION
From now the `rhel-8-y` status is the latest unreleased RHEL-8 and the `rhel-x` status is pre-released RHEL-9.