### PR TITLE
Always install sssd.conf to enable files domain

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,6 @@
   when:
     - tlog_use_sssd | bool
     - "'sssd' in ansible_facts.packages"
-    - ansible_facts.packages.sssd[0].version is version("2.1", "<")
   notify: tlog_handler restart sssd
 
 - name: configure sssd session recording config


### PR DESCRIPTION
This fixes an issue in RHEL9 where SSSD won't start due to changing the implicit files domain no longer being enabled. We were installing /etc/sssd/sssd.conf with `enable_files_domain = true` in earlier versions of SSSD, now let's just always add this file when using SSSD.