### PR TITLE
tests_default_wrapper.yml requires python3-libselinux and policycoreutils.

### DIFF
--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -10,6 +10,22 @@
             suffix: .yaml
           register: tempinventory
 
+        - name: Get os version of the control node
+          command: "hostnamectl"
+          register: __result
+
+        - name: Ensure required packages exist
+          package:
+            name:
+              - python3-libselinux
+              - policycoreutils
+            state: present
+          when: __result.stdout is
+                  search("Operating System. Red Hat Enterprise Linux 9.*")
+                or __result.stdout is
+                  search("Operating System. CentOS Linux 9.*")
+          delegate_to: localhost
+
         - name: Create static inventory from hostvars
           template:
             src: inventory.yaml.j2


### PR DESCRIPTION
If the control node is RHEL-9 or CentOS-9, ensure the packages are on the control node.

Fixing this error when tests_default_wrapper.yml is run from the control node where the packages are missing.
```
TASK [Create static inventory from hostvars] ***********************************
task path: /path/to/roles/linux-system-roles.tlog/tests/tests_default_wrapper.yml:13
fatal: [image.qcow2]: FAILED! => {"changed": false, "checksum": "c41aea8314151fd7512415859b81a50d291bd8ef", "msg": "Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!"}
```