### PR TITLE
System Roles should consistently use ansible_managed in configuration files it manages

### DIFF
--- a/templates/sssd-session-recording.conf
+++ b/templates/sssd-session-recording.conf
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [session_recording]
 scope={{ tlog_scope_sssd }}
 users={{ tlog_users_sssd|join(', ') }}

--- a/templates/sssd.conf
+++ b/templates/sssd.conf
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [sssd]
 enable_files_domain = true
 services = nss

--- a/templates/tlog-rec-session.conf
+++ b/templates/tlog-rec-session.conf
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment('c') }}
 //
 // Tlog-rec-session system-wide configuration. See tlog-rec-session.conf(5) for details.
 // This file uses JSON format with both C and C++ comments allowed.


### PR DESCRIPTION
bz#2044640

Commented files by tests_sssd.yml:
```
==> /etc/sssd/sssd.conf <==
#
# Ansible managed
#
[sssd]
enable_files_domain = true
services = nss

==> /etc/sssd/conf.d/sssd-session-recording.conf <==
#
# Ansible managed
#
[session_recording]
scope=all
users=mike, john

==> /etc/tlog/tlog-rec-session.conf <==
//
// Ansible managed
//
//
// Tlog-rec-session system-wide configuration. See tlog-rec-session.conf(5) for details.
// This file uses JSON format with both C and C++ comments allowed.
```