### PR TITLE
tlog does not own sssd.conf - so use ini_file to manage it

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,19 @@
 ---
+- name: Set platform/version specific variables
+  include_vars: "{{ __tlog_vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __tlog_vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __tlog_vars_file is file
+
 - name: install session recording packages
   package:
     name: "{{ __tlog_packages }}"
@@ -14,16 +29,25 @@
     - "'cockpit' in ansible_facts.packages"
 
 - name: configure basic sssd
-  template:
-    src: sssd.conf
-    dest: "{{ __tlog_sssd_conf }}"
+  ini_file:
+    path: "{{ __tlog_sssd_conf }}"
+    section: sssd
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    state: present
+    create: true
     owner: root
     group: root
     mode: 0600
-    force: no
+  loop:
+    - key: enable_files_domain
+      value: "true"
+    - key: services
+      value: nss
   when:
     - tlog_use_sssd | bool
     - "'sssd' in ansible_facts.packages"
+    - __tlog_enable_sssd_files | bool
   notify: tlog_handler restart sssd
 
 - name: configure sssd session recording config

--- a/templates/sssd.conf
+++ b/templates/sssd.conf
@@ -1,4 +1,0 @@
-{{ ansible_managed | comment }}
-[sssd]
-enable_files_domain = true
-services = nss

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,1 @@
+__tlog_enable_sssd_files: true

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+__tlog_enable_sssd_files: true

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,0 +1,1 @@
+__tlog_enable_sssd_files: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,3 +10,5 @@ __tlog_sssd_conf: /etc/sssd/sssd.conf
 __tlog_sssd_session_recording_conf: >-
   /etc/sssd/conf.d/sssd-session-recording.conf
 __tlog_rec_session_conf: /etc/tlog/tlog-rec-session.conf
+# by default, do not enable files domain in sssd.conf
+__tlog_enable_sssd_files: false


### PR DESCRIPTION
tlog does not own sssd.conf, so we cannot use a template for it,
since that may wipe out changes someone else made.  Instead, use
`ini_file` (and add a requirement on `community.general`) to manage
the necessary entries in the file.

In addition, this only needs to be done on rhel9+ and fedora, so on
rhel8, skip this step.