### PR TITLE
Execute authselect to update nsswitch

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,6 +74,7 @@
 - name: update nsswitch
   command: authselect select sssd with-files-domain --force
   when:
+    - not ansible_check_mode
     - tlog_use_sssd
     - '"with-files-domain" in __tlog_authselect_features.stdout'
     - not "with-files-domain" in __tlog_authselect_current.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,25 @@
   when: tlog_use_sssd
   notify: tlog_handler restart sssd
 
+- name: Check with-files-domain feature exists
+  command: authselect list-features sssd
+  register: __tlog_authselect_features
+  changed_when: false
+
+- name: Check if files domain is currently enabled
+  command: authselect current
+  register: __tlog_authselect_current
+  changed_when: false
+  failed_when: __tlog_authselect_current.rc not in [0, 2]
+
+- name: update nsswitch
+  command: authselect select sssd with-files-domain --force
+  when:
+    - tlog_use_sssd
+    - '"with-files-domain" in __tlog_authselect_features.stdout'
+    - not "with-files-domain" in __tlog_authselect_current.stdout
+  notify: tlog_handler restart sssd
+
 - name: configure tlog rec session
   template:
     src: tlog-rec-session.conf

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 __tlog_packages:
   - tlog
   - sssd
+  - authselect
 __tlog_cockpit_packages:
   - cockpit-session-recording
 __tlog_writer: journal


### PR DESCRIPTION
SSSD implicit files provider is not enabled by default on some OSs, we need to update 'passwd' and 'group' in nsswitch.conf in these cases.

Hi @richm It is expected this authselect command will fail on RHEL8 and Fedora 34 and lower, because `with-files-domain` authselect feature is not added there.  What would be the best way to handle this?
~~~
[error] Unknown profile feature [with-files-domain]
[error] Unable to activate profile [sssd] [22]: Invalid argument
Unable to activate profile [22]: Invalid argument
~~~