### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 - name: Set platform/version specific variables
-  include_vars: "{{ __tlog_vars_file }}"
-  loop:
-    - "{{ ansible_facts['os_family'] }}.yml"
-    - "{{ ansible_facts['distribution'] }}.yml"
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_major_version'] }}.yml
-    - >-
-      {{ ansible_facts['distribution'] ~ '_' ~
-      ansible_facts['distribution_version'] }}.yml
-  vars:
-    __tlog_vars_file: "{{ role_path }}/vars/{{ item }}"
-  when: __tlog_vars_file is file
+  include_tasks: set_vars.yml
 
 - name: install session recording packages
   package:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__tlog_required_facts) == __tlog_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __vars_file is file

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.tlog
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __tlog_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -4,3 +4,4 @@
 
   roles:
     - linux-system-roles.tlog
+  gather_facts: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,3 +13,10 @@ __tlog_sssd_session_recording_conf: >-
 __tlog_rec_session_conf: /etc/tlog/tlog-rec-session.conf
 # by default, do not enable files domain in sssd.conf
 __tlog_enable_sssd_files: false
+
+# ansible_facts required by the role
+__tlog_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.