### PR TITLE
Add test for sssd files domain configured properly

### DIFF
--- a/tests/check_sssd_files_provider.yml
+++ b/tests/check_sssd_files_provider.yml
@@ -1,0 +1,27 @@
+- name: Check with-files-domain feature exists
+  command: authselect list-features sssd
+  register: __tlog_authselect_features
+  changed_when: false
+
+- name: Check if files domain is currently enabled
+  command: authselect current
+  register: __tlog_authselect_current
+  changed_when: false
+  failed_when: __tlog_authselect_current.rc not in [0, 2]
+
+- name: Read nsswitch.conf
+  slurp:
+    src: /etc/nsswitch.conf
+  register: __nsswitch_slurp
+
+- name: Decode nsswitch content
+  set_fact:
+    __nsswitch_contents: "{{ __nsswitch_slurp ['content'] | b64decode }}"
+
+- name: Check if files domain enabled and nsswitch set correctly
+  assert:
+    that:
+      - __nsswitch_contents | regex_search('^passwd:\\s+sss', multiline=True)
+      - '"with-files-domain" in __tlog_authselect_current.stdout'
+  when:
+    - '"with-files-domain" in __tlog_authselect_features.stdout'

--- a/tests/tests_sssd.yml
+++ b/tests/tests_sssd.yml
@@ -16,6 +16,9 @@
       vars:
         tlog_scope_sssd: all
 
+    - name: Check sssd files provider setup properly
+      import_tasks: check_sssd_files_provider.yml
+
     - name: Run sssd tests
       import_tasks: run_sssd_tests.yml
 


### PR DESCRIPTION
Adding a test to confirm that the sssd files domain is enabled and
nsswitch.conf modified on systems where it is needed.