### PR TITLE
Unconditionally enable the files provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ includes these collections/modules, you should have to do nothing.
 Role Variables
 --------------
 
-Configure session recording with SSSD, the preferred way of managing recorded users or groups:
+Configure session recording with SSSD, the preferred way of managing recorded users or groups.
+This causes the SSSD files provider to be enabled explicitly.
 
 - `tlog_use_sssd` (default: `yes`)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,6 @@
   when:
     - tlog_use_sssd | bool
     - "'sssd' in ansible_facts.packages"
-    - __tlog_enable_sssd_files | bool
   notify: tlog_handler restart sssd
 
 - name: configure sssd session recording config

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,1 +1,0 @@
-__tlog_enable_sssd_files: true

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,1 +1,0 @@
-__tlog_enable_sssd_files: true

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,1 +1,0 @@
-__tlog_enable_sssd_files: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,8 +11,6 @@ __tlog_sssd_conf: /etc/sssd/sssd.conf
 __tlog_sssd_session_recording_conf: >-
   /etc/sssd/conf.d/sssd-session-recording.conf
 __tlog_rec_session_conf: /etc/tlog/tlog-rec-session.conf
-# by default, do not enable files domain in sssd.conf
-__tlog_enable_sssd_files: false
 
 # ansible_facts required by the role
 __tlog_required_facts:


### PR DESCRIPTION
The implicity files provider is now disabled in RHEL 8.8+, RHEL9+, and Fedora.

We will need to stop relying on the files provider and switch to the SSSD proxy provider, but this is a worthwhile short term fix.