### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/sssd-session-recording.conf
+++ b/templates/sssd-session-recording.conf
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:tlog" | comment(prefix="", postfix="") }}
 [session_recording]
 scope={{ tlog_scope_sssd }}
 users={{ tlog_users_sssd | join(', ') }}

--- a/templates/tlog-rec-session.conf
+++ b/templates/tlog-rec-session.conf
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment('c') }}
-{{ "system_role:tlog" | comment(prefix="", postfix="") }}
+{{ "system_role:tlog" | comment('c', prefix="", postfix="") }}
 //
 // Tlog-rec-session system-wide configuration. See tlog-rec-session.conf(5) for details.
 // This file uses JSON format with both C and C++ comments allowed.

--- a/templates/tlog-rec-session.conf
+++ b/templates/tlog-rec-session.conf
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment('c') }}
+{{ "system_role:tlog" | comment(prefix="", postfix="") }}
 //
 // Tlog-rec-session system-wide configuration. See tlog-rec-session.conf(5) for details.
 // This file uses JSON format with both C and C++ comments allowed.


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:tlog
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.