### PR TITLE
ansible-lint - use changed_when for conditional tasks; fix indentation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,7 @@
     - '"with-files-domain" in __tlog_authselect_features.stdout'
     - not "with-files-domain" in __tlog_authselect_current.stdout
   notify: Handler tlog_handler restart sssd
+  changed_when: true
 
 - name: Configure tlog rec session
   template:

--- a/tests/tests_cockpit.yml
+++ b/tests/tests_cockpit.yml
@@ -2,47 +2,47 @@
 - name: Test support for autoinstall of cockpit-session-recording
   hosts: all
   tasks:
-  - name: Get the rpm package facts
-    package_facts:
+    - name: Get the rpm package facts
+      package_facts:
 
-  - name: Record cockpit installation status
-    set_fact:
-      cockpit_installed: "{{ 'cockpit' in ansible_facts.packages }}"
+    - name: Record cockpit installation status
+      set_fact:
+        cockpit_installed: "{{ 'cockpit' in ansible_facts.packages }}"
 
-  - name: Remove cockpit if installed
-    package:
-      name: cockpit
-      state: absent
+    - name: Remove cockpit if installed
+      package:
+        name: cockpit
+        state: absent
 
-  - name: Test role without cockpit
-    import_role:
-      name: linux-system-roles.tlog
+    - name: Test role without cockpit
+      import_role:
+        name: linux-system-roles.tlog
 
-  - name: Get the rpm package facts without cockpit installed
-    package_facts:
+    - name: Get the rpm package facts without cockpit installed
+      package_facts:
 
-  - name: Check that cockpit-session-recording is not installed
-    assert:
-      that: "'cockpit-session-recording' not in ansible_facts.packages"
+    - name: Check that cockpit-session-recording is not installed
+      assert:
+        that: "'cockpit-session-recording' not in ansible_facts.packages"
 
-  - name: Install cockpit
-    package:
-      name: cockpit
-      state: present
+    - name: Install cockpit
+      package:
+        name: cockpit
+        state: present
 
-  - name: Test role with cockpit
-    import_role:
-      name: linux-system-roles.tlog
+    - name: Test role with cockpit
+      import_role:
+        name: linux-system-roles.tlog
 
-  - name: Get the rpm package facts with cockpit installed
-    package_facts:
+    - name: Get the rpm package facts with cockpit installed
+      package_facts:
 
-  - name: Check that cockpit-session-recording is installed
-    assert:
-      that: "'cockpit-session-recording' in ansible_facts.packages"
+    - name: Check that cockpit-session-recording is installed
+      assert:
+        that: "'cockpit-session-recording' in ansible_facts.packages"
 
-  - name: Return Cockpit to previous install state
-    package:
-      name: cockpit
-      state: absent
-    when: not cockpit_installed
+    - name: Return Cockpit to previous install state
+      package:
+        name: cockpit
+        state: absent
+      when: not cockpit_installed


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even for
conditional tasks

fix indentation

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
