### PR TITLE
test: check generated files for ansible_managed, fingerprint

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get file
+  slurp:
+    path: "{{ __file }}"
+  register: __content
+  when: not __file_content is defined
+
+- name: Check for presence of ansible managed header, fingerprint
+  assert:
+    that:
+      - ansible_managed in content
+      - __fingerprint in content
+  vars:
+    content: "{{ (__file_content | d(__content)).content | b64decode }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment(__comment_type | d("plain")) }}

--- a/tests/tests_sssd.yml
+++ b/tests/tests_sssd.yml
@@ -38,8 +38,9 @@
       import_tasks: run_sssd_tests.yml
 
     - name: Run role with excluded users and groups
-      import_role:
+      include_role:  # instead of import - so we can use public:
         name: linux-system-roles.tlog
+        public: true
       vars:
         tlog_scope_sssd: all
         tlog_exclude_users_sssd:
@@ -50,3 +51,16 @@
 
     - name: Run sssd tests
       import_tasks: run_sssd_tests.yml
+
+    - name: Check for ansible_managed, fingerprint in generated files
+      include_tasks: tasks/check_header.yml
+      vars:
+        __file: "{{ __tlog_sssd_session_recording_conf }}"
+        __fingerprint: "system_role:tlog"
+
+    - name: Check for ansible_managed, fingerprint in generated files
+      include_tasks: tasks/check_header.yml
+      vars:
+        __file: "{{ __tlog_rec_session_conf }}"
+        __fingerprint: "system_role:tlog"
+        __comment_type: c


### PR DESCRIPTION
Add the following files: tests/tasks/check_header.yml and
tests/templates/get_ansible_managed.j2.
Use check_header.yml to check generated files for the ansible_managed
and fingerprint headers.
check_header.yml takes these parameters.  `fingerprint` is required,
and one of `__file` or `__file_content`:

* `__file` - the full path of the file to check e.g. `/etc/realmd.conf`
* `__file_content` - the output of `slurp` of the file
* `__fingerprint` - required - the fingerprint string `system_role:$ROLENAME` e.g.
  `__fingerprint: "system_role:postfix"`
* `__comment_type` - optional, default `plain` - the type of comments used

e.g. `__comment_type: c` for C/C++-style comments.  `plain` uses `#`.
See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files
for the different types of comment styles supported.

Example:
```
- name: Check generated files for ansible_managed, fingerprint
  include_tasks: tasks/check_header.yml
  vars:
    __file: /etc/myfile.conf
    __fingerprint: "system_role:my_role"
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
