### PR TITLE
docs: remove unused Dependencies section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,31 @@
-tlog
-====
+# tlog
+
 ![CI Testing](https://github.com/linux-system-roles/tlog/workflows/tox/badge.svg)
 
-This role configures a system for [Terminal session recording](https://github.com/scribery).
-The role will configure tlog to log recording data to the systemd journal.
+This role configures a system for [Terminal session
+recording](https://github.com/scribery). The role will configure tlog to log
+recording data to the systemd journal.
 
-Requirements
-------------
+## Requirements
 
 This role is only supported on RHEL8/CentOS8 and Fedora distributions.
 
+### Collection requirements
+
 This role requires the `ini_file` module from `community.general`.  If you are
 using `ansible-core` you must install that collection.
+
 ```
 ansible-galaxy collection install -vv -r meta/collection-requirements.yml
 ```
+
 If you are using Ansible Engine 2.9, or are using an Ansible bundle which
 includes these collections/modules, you should have to do nothing.
 
-Role Variables
---------------
+## Role Variables
 
-Configure session recording with SSSD, the preferred way of managing recorded users or groups.
-This causes the SSSD files provider to be enabled explicitly.
+Configure session recording with SSSD, the preferred way of managing recorded
+users or groups. This causes the SSSD files provider to be enabled explicitly.
 
 - `tlog_use_sssd` (default: `true`)
 
@@ -48,13 +51,8 @@ scope=all):
 
 - `tlog_exclude_groups_sssd` (default: `[]`)
 
-Dependencies
-------------
+## Example Playbook
 
-This role has no dependencies currently.
-
-Example Playbook
-----------------
 ```yaml
 - name: Deploy session recording
   hosts: all
@@ -65,17 +63,16 @@ Example Playbook
     tlog_users_sssd:
       - recordeduser
 ```
-Testing
--------
-Testing is done with the `tests/tests*.yml` playbooks.
 
-License
--------
+## Testing
+
+Testing is done with the `tests/tests_*.yml` playbooks.  See `contributing.md`.
+
+## License
 
 GPL v3.0
 
-Author Information
-------------------
+## Author Information
 
 - Nathan Kinder @nkinder
 


### PR DESCRIPTION
remove unused Dependencies section in README - it is confusing
to users who look at the README, see the `Dependencies` section
that says `None`, and think that there are no dependencies for
the role, when the actual dependencies are listed in the
`Requirements` section which is not even near the `Dependencies`
section.  So consistently use the `Requirements` section and
get rid of the `Dependencies` section.

In addition, for roles that use external collections, they have a
`meta/collection-requirements.yml` file, and the README lists
these requirements and instructions.  However, these are only
required for github and Galaxy users, and not for users who
use the packaged roles, where it is confusing to see instructions
about installing requirements when none are needed.  We need to
make it easier to remove these sections when packaging.

Use regular markdown header style instead of alternate style
to make it easier for the parser.

Fix some markdownlint issues.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
