### PR TITLE
ci: support ansible-lint and ansible-test 2.16

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,6 +21,6 @@ exclude_paths:
   - .markdownlint.yaml
   - examples/roles/
 mock_modules:
-  - ini_file
+  - community.general.ini_file
 mock_roles:
   - linux-system-roles.tlog

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     - "'cockpit' in ansible_facts.packages"
 
 - name: Configure sssd services section
-  ini_file:
+  community.general.ini_file:
     path: "{{ __tlog_sssd_conf }}"
     section: sssd
     option: "{{ item.key }}"
@@ -41,7 +41,7 @@
   notify: Handler tlog_handler restart sssd
 
 - name: Configure sssd proxy provider domain
-  ini_file:
+  community.general.ini_file:
     path: "{{ __tlog_sssd_conf }}"
     section: domain/nssfiles
     option: "{{ item.key }}"


### PR DESCRIPTION
Fix yamllint issue with markdownlint config

Use FQCN for community.general modules

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
