### PR TITLE
refactor: Support with-tlog authselect feature

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,12 +73,20 @@
   when: tlog_use_sssd
   notify: Handler tlog_handler restart sssd
 
-- name: Check with-files-domain feature exists
+- name: Check appropriate authselect features exists
   command: authselect list-features sssd
   register: __tlog_authselect_features
   changed_when: false
 
-- name: Check if files domain is currently enabled
+- name: Enable authselect profile with tlog feature
+  command: authselect select sssd with-tlog --force
+  changed_when: true
+  when:
+    - not ansible_check_mode
+    - tlog_use_sssd | bool
+    - '"with-tlog" in __tlog_authselect_features.stdout'
+
+- name: Check which authselect features are currently enabled
   command: authselect current
   register: __tlog_authselect_current
   changed_when: false

--- a/tests/check_sssd_with_tlog.yml
+++ b/tests/check_sssd_with_tlog.yml
@@ -1,0 +1,25 @@
+---
+- name: Check with-tlog feature exists
+  command: authselect list-features sssd
+  register: __tlog_authselect_features
+  changed_when: false
+
+- name: Check if with-tlog authselect feature is currently enabled
+  command: authselect current
+  register: __tlog_authselect_current
+  changed_when: false
+  failed_when: __tlog_authselect_current.rc not in [0, 2]
+
+- name: Read nsswitch.conf
+  slurp:
+    src: /etc/nsswitch.conf
+  register: __nsswitch_slurp
+
+- name: Check if with tlog authselect feature enabled and nsswitch set correctly
+  assert:
+    that:
+      - __nsswitch_contents | regex_search('^passwd:\\s+sss', multiline=True)
+      - '"with-tlog" in __tlog_authselect_current.stdout'
+  when: '"with-tlog" in __tlog_authselect_features.stdout'
+  vars:
+    __nsswitch_contents: "{{ __nsswitch_slurp['content'] | b64decode }}"

--- a/tests/tests_sssd.yml
+++ b/tests/tests_sssd.yml
@@ -19,7 +19,13 @@
       vars:
         tlog_scope_sssd: all
 
-    - name: Check sssd files provider setup properly
+    - name: Check sssd authselect with tlog setup properly
+      import_tasks: check_sssd_with_tlog.yml
+
+    - name: Run sssd tests
+      import_tasks: run_sssd_tests.yml
+
+    - name: Check authselect files provider setup properly
       import_tasks: check_sssd_files_provider.yml
 
     - name: Run sssd tests


### PR DESCRIPTION
authselect removes `with-files-domain` feature in F40+/RHEL10+, it is replaced by 'with-tlog' feature because the SSSD files domain is removed entirely there. This will not be backported to RHEL9 therefore we still need to execute 'authselect select sssd with-files-domain' on RHEL9 and older Fedora versions.