### PR TITLE
ci: ansible-lint action now requires absolute directory

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v24
         with:
-          working_directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -44,4 +44,4 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           testing-type: sanity  # wokeignore:rule=sanity
-          collection-src-directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          collection-src-directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}


### PR DESCRIPTION
the change made for
https://github.com/ansible/ansible-lint/commit/b4018c22f8fe8371bd6845d0cd62cebea54ce012
means that ansible-lint now needs an absolute path for the working directory

Go ahead and make ansible-test use absolute path too just in case they decide
to make the same change.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
