### PR TITLE
fix: Consider "degraded" systemd state as booted

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -6,7 +6,7 @@
     difference(ansible_facts.keys() | list) | length > 0
 
 - name: Determine if system is ostree and set flag
-  when: not __tlog_is_ostree is defined
+  when: __tlog_is_ostree is not defined
   block:
     - name: Check if system is ostree
       stat:
@@ -18,7 +18,7 @@
         __tlog_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
 - name: Determine if system is booted with systemd
-  when: not __tlog_is_booted is defined
+  when: __tlog_is_booted is not defined
   block:
     - name: Run systemctl
       # noqa command-instead-of-module
@@ -30,7 +30,7 @@
     - name: Require installed systemd
       fail:
         msg: "Error: This role requires systemd to be installed."
-      when: __is_system_running.msg is defined and "No such file or directory" in __is_system_running.msg
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
 
     - name: Set flag to indicate that systemd runtime operations are available
       set_fact:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -35,7 +35,7 @@
     - name: Set flag to indicate that systemd runtime operations are available
       set_fact:
         # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
-        __tlog_is_booted: "{{ __is_system_running.stdout not in ['offline', 'degraded'] }}"
+        __tlog_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
 
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"


### PR DESCRIPTION
This was a thinko in commit abffab1b905af.

---

Plus some syntactic updates suggested by sourcery.ai and @richm in https://github.com/linux-system-roles/mssql/pull/349

## Summary by Sourcery

Standardize Ansible condition syntax, refine systemctl error handling, and update systemd boot detection to treat the 'degraded' state as booted

Bug Fixes:
- Treat 'degraded' systemd state as booted

Enhancements:
- Use 'is not defined' syntax for Ansible when conditions
- Simplify systemctl error check with a default filter