### PR TITLE
fix: Set __is_system_running in check mode

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -25,6 +25,7 @@
       command: systemctl is-system-running
       register: __is_system_running
       changed_when: false
+      check_mode: false
       failed_when: false
 
     - name: Require installed systemd

--- a/tests/check_sssd_with_tlog.yml
+++ b/tests/check_sssd_with_tlog.yml
@@ -18,7 +18,7 @@
 - name: Check if with tlog authselect feature enabled and nsswitch set correctly
   assert:
     that:
-      - __nsswitch_contents | regex_search('^passwd:\\s+sss', multiline=True)
+      - __nsswitch_contents | regex_search('^passwd:\\s+sss', multiline=True) | length > 0
       - '"with-tlog" in __tlog_authselect_current.stdout'
   when: '"with-tlog" in __tlog_authselect_features.stdout'
   vars:

--- a/tests/run_sssd_tests.yml
+++ b/tests/run_sssd_tests.yml
@@ -19,12 +19,17 @@
 - name: Verify that contents of sssd conf are correct
   assert:
     that:
-      - __tlog_conf_content.stdout.find('scope={{ tlog_scope_sssd }}')
+      - ('scope=' + tlog_scope_sssd) in __tlog_conf_content.stdout
       # yamllint disable-line rule:line-length
-      - __tlog_conf_content.stdout.find('users={{ tlog_users_sssd | join(', ') }}')
+      - ('users=' + tlog_users_sssd_str) in __tlog_conf_content.stdout
       # yamllint disable-line rule:line-length
-      - __tlog_conf_content.stdout.find('groups={{ tlog_groups_sssd | join(', ') }}')
+      - ('groups=' + tlog_groups_sssd_str) in __tlog_conf_content.stdout
       # yamllint disable-line rule:line-length
-      - __tlog_conf_content.stdout.find('exclude_users={{ tlog_exclude_users_sssd | join(', ') }}')
+      - ('exclude_users=' + tlog_exclude_users_sssd_str) in __tlog_conf_content.stdout
       # yamllint disable-line rule:line-length
-      - __tlog_conf_content.stdout.find('exclude_groups={{ tlog_exclude_groups_sssd | join(', ') }}')
+      - ('exclude_groups=' + tlog_exclude_groups_sssd_str) in __tlog_conf_content.stdout
+  vars:
+    tlog_users_sssd_str: "{{ tlog_users_sssd | join(', ') }}"
+    tlog_groups_sssd_str: "{{ tlog_groups_sssd | join(', ') }}"
+    tlog_exclude_users_sssd_str: "{{ tlog_exclude_users_sssd | join(', ') }}"
+    tlog_exclude_groups_sssd_str: "{{ tlog_exclude_groups_sssd | join(', ') }}"

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
-    content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    content: "{{ __content.content | b64decode }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_sssd.yml
+++ b/tests/tests_sssd.yml
@@ -21,27 +21,24 @@
     - name: Run sssd tests
       import_tasks: run_sssd_tests.yml
 
-    - name: Run role with tlog_scope_sssd all
-      import_role:
-        name: linux-system-roles.tlog
+    - name: Test role with tlog_scope_sssd all
       vars:
         tlog_scope_sssd: all
+      block:
+        - name: Run role
+          import_role:
+            name: linux-system-roles.tlog
 
-    - name: Check sssd authselect with tlog setup properly
-      import_tasks: check_sssd_with_tlog.yml
+        - name: Check sssd authselect with tlog setup properly
+          import_tasks: check_sssd_with_tlog.yml
 
-    - name: Run sssd tests
-      import_tasks: run_sssd_tests.yml
+        - name: Run sssd tests
+          import_tasks: run_sssd_tests.yml
 
-    - name: Check authselect files provider setup properly
-      import_tasks: check_sssd_files_provider.yml
+        - name: Check authselect files provider setup properly
+          import_tasks: check_sssd_files_provider.yml
 
-    - name: Run sssd tests
-      import_tasks: run_sssd_tests.yml
-
-    - name: Run role with tlog_scope_sssd some
-      import_role:
-        name: linux-system-roles.tlog
+    - name: Test role with tlog_scope_sssd some
       vars:
         tlog_scope_sssd: some
         tlog_users_sssd:
@@ -50,14 +47,15 @@
         tlog_groups_sssd:
           - teachers
           - students
+      block:
+        - name: Run role
+          import_role:
+            name: linux-system-roles.tlog
 
-    - name: Run sssd tests
-      import_tasks: run_sssd_tests.yml
+        - name: Run sssd tests
+          import_tasks: run_sssd_tests.yml
 
-    - name: Run role with excluded users and groups
-      include_role:  # instead of import - so we can use public:
-        name: linux-system-roles.tlog
-        public: true
+    - name: Test role with excluded users and groups
       vars:
         tlog_scope_sssd: all
         tlog_exclude_users_sssd:
@@ -65,9 +63,13 @@
           - james
         tlog_exclude_groups_sssd:
           - admins
+      block:
+        - name: Run role
+          import_role:
+            name: linux-system-roles.tlog
 
-    - name: Run sssd tests
-      import_tasks: run_sssd_tests.yml
+        - name: Run sssd tests
+          import_tasks: run_sssd_tests.yml
 
     - name: Check for ansible_managed, fingerprint in generated files
       include_tasks: tasks/check_header.yml


### PR DESCRIPTION
Cause: `systemctl is-system-running` was not called in `--check` mode.

Consequence: The "Determine if system is booted with systemd" step failed in check mode as the `__is_system_running` variable was not populated.

Fix: Force calling `systemctl is-system-running` in check mode. It does not modify the system and the outcome is very influential for what the role does.


---

See failure in #109 [log](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_tlog-109_CentOS-Stream-8-2.9_20250601-035500/artifacts/tests_default_wrapper-ANSIBLE-2.9-test_playbooks_parallel-FAIL.log) and https://github.com/linux-system-roles/tlog/pull/170#issuecomment-2959893192 ff. I cannot reproduce this locally, as
```
tox -e qemu-ansible-2.9 -- --image-name centos-8 --log-level=debug tests/tests_default_wrapper.yml
```
fails in a completely different way. So throwing this at CI.

## Summary by Sourcery

Force execution of `systemctl is-system-running` in check mode and update SSSD test playbooks to align assertions and structure with this behavior.

Bug Fixes:
- Always run `systemctl is-system-running` with check_mode disabled to populate the `__is_system_running` variable.

Tests:
- Restructure SSSD tests to group role invocations and checks within blocks and rename tasks for clarity.
- Refactor `run_sssd_tests.yml` assertions to use `in` operators with helper string variables for list-based parameters.
- Update `check_sssd_with_tlog.yml` assertion to explicitly check for regex match length.