### PR TITLE
refactor: fix ansible lint unique name issue

### DIFF
--- a/tests/tests_sssd.yml
+++ b/tests/tests_sssd.yml
@@ -77,7 +77,7 @@
         __file: "{{ __tlog_sssd_session_recording_conf }}"
         __fingerprint: "system_role:tlog"
 
-    - name: Check for ansible_managed, fingerprint in generated files
+    - name: Check for ansible_managed, fingerprint in generated files - 2
       include_tasks: tasks/check_header.yml
       vars:
         __file: "{{ __tlog_rec_session_conf }}"


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Rename Ansible task in tests/tests_sssd.yml to ensure a unique name and satisfy ansible-lint