### PR TITLE
test: default wrapper should use local connection if local

### DIFF
--- a/tests/inventory.yaml.j2
+++ b/tests/inventory.yaml.j2
@@ -1,11 +1,16 @@
 all:
   hosts:
     {{ inventory_hostname }}:
-{% for key in ["ansible_all_ipv4_addresses", "ansible_all_ipv6_addresses",
+{% if __ansible_connection == "local" %}
+      ansible_connection: local
+      ansible_host: localhost
+{% else %}
+{%   for key in ["ansible_all_ipv4_addresses", "ansible_all_ipv6_addresses",
                  "ansible_default_ipv4", "ansible_default_ipv6", "ansible_host",
                  "ansible_port", "ansible_ssh_common_args",
                  "ansible_ssh_private_key_file","ansible_user"] %}
-{%   if key in hostvars[inventory_hostname] %}
+{%     if key in hostvars[inventory_hostname] %}
       {{ key }}: {{ hostvars[inventory_hostname][key] }}
-{%   endif %}
-{% endfor %}
+{%     endif %}
+{%   endfor %}
+{% endif %}

--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -5,6 +5,10 @@
   tags:
     - tests::booted
   tasks:
+    - name: Save connection method
+      set_fact:
+        __ansible_connection: "{{ ansible_connection }}"
+
     - name: Run test
       block:
         - name: Create temporary file
@@ -12,6 +16,7 @@
             state: file
             suffix: .yaml
           register: tempinventory
+          delegate_to: localhost
 
         - name: Create static inventory from hostvars
           template:


### PR DESCRIPTION
tests_default_wrapper.yml should use local connection for the nested
test if the test is using local connection

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Adjust the inventory template to explicitly set local connection parameters when running nested tests with a local connection, and retain the existing host variable mappings for non-local connections.

Bug Fixes:
- Ensure the default test wrapper uses a local connection and localhost for nested tests when ansible_connection is set to local

Enhancements:
- Modify tests/inventory.yaml.j2 to conditionally emit ansible_connection and ansible_host settings for local hosts