### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - name: Get the rpm package facts
   package_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Install cockpit session recording
   package:


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like package_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - package_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Gate package_facts logging with a verbosity-based no_log condition so facts output is hidden in normal runs but visible at higher verbosity.