### PR TITLE
test: ensure fingerprint test works in check mode

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -20,25 +20,10 @@
       vars:
         __tlog_write_log_file: true
 
-    - name: Get fingerprint entries from journal
-      ansible.builtin.shell:
-        executable: /bin/bash
-        cmd: >-
-          set -eo pipefail;
-          journalctl --since "{{ __journal_start_time }}" --no-pager |
-          grep -v " Invoked with" |
-          grep "sr_fingerprint.*role_name=tlog"
-      register: __register_journal_fingerprints
-      changed_when: false
-      when: __register_dev_log.stat.exists
-
-    - name: Check that the log file was written
-      ansible.builtin.slurp:
-        path: /var/log/sysroles.jsonl
-      register: __register_log_file
-
     - name: Verify log file and journal fingerprints
-      when: __register_dev_log.stat.exists
+      when:
+        - __register_dev_log.stat.exists
+        - not ansible_check_mode
       vars:
         __journal_lines: "{{ __register_journal_fingerprints.stdout_lines }}"
         __journal_begin: "{{ __journal_lines | select('search', 'status=begin') | list }}"
@@ -47,6 +32,23 @@
         __success_date: "{{ (__journal_success[0] | regex_search('date=([^ ]+)', '\\1'))[0] }}"
         __file_content: "{{ __register_log_file.content | b64decode }}"
       block:
+        - name: Get fingerprint entries from journal
+          ansible.builtin.shell:
+            executable: /bin/bash
+            cmd: >-
+              set -eo pipefail;
+              journalctl --since "{{ __journal_start_time }}" --no-pager |
+              grep -v " Invoked with" |
+              grep "sr_fingerprint.*role_name=tlog"
+          register: __register_journal_fingerprints
+          changed_when: false
+          when: __register_dev_log.stat.exists
+
+        - name: Check that the log file was written
+          ansible.builtin.slurp:
+            path: /var/log/sysroles.jsonl
+          register: __register_log_file
+
         - name: Print contents of logs
           debug:
             var: item

--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -31,6 +31,15 @@
             --check tests_default.yml
           delegate_to: localhost
           changed_when: false
+          register: __check_mode_result
+          failed_when: __check_mode_result is failed
+            or __check_mode_result.stdout_lines | select('search', _begin_pattern) | list | length == 0
+            or __check_mode_result.stdout_lines | select('search', _success_pattern) | list | length == 0
+          vars:
+            _begin_pattern: >-
+              Check mode: message not logged - .* role_name=tlog .* status=begin .* ansible_check_mode=[Tt]rue
+            _success_pattern: >-
+              Check mode: message not logged - .* role_name=tlog .* status=success .* ansible_check_mode=[Tt]rue
 
       always:
         - name: Remove the temporary file


### PR DESCRIPTION
The fingerprint journal messages and the fingerprint log file
are not written in check mode.  Ensure that the correct messages
are written in check mode.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fingerprint verification is now skipped during Ansible check mode and when `/dev/log` is unavailable.
  * Verification-related log checks now run only when verification is applicable.
  * Check-mode validation now confirms successful execution and expected log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->