### PR TITLE
feat: Argument spec implementation for tlog role

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+---
+argument_specs:
+  main:
+    short_description: The tlog role.
+    description: >
+      The tlog role configures a system for terminal session recording
+      using tlog. The role installs the necessary packages, configures
+      SSSD for session recording, and sets up the tlog-rec-session
+      configuration. Recording data is logged to the systemd journal.
+    options:
+      tlog_use_sssd:
+        type: bool
+        default: true
+        description: >
+          Whether to configure session recording with SSSD. When
+          enabled, the SSSD files provider is configured explicitly.
+      tlog_scope_sssd:
+        type: str
+        default: none
+        choices:
+          - all
+          - some
+          - none
+        description: >
+          The SSSD session recording scope. Use `all` to record all
+          sessions, `some` to record only sessions of specified users
+          and groups, or `none` to disable session recording.
+      tlog_users_sssd:
+        type: list
+        elements: str
+        default: []
+        description: >
+          List of users whose sessions should be recorded. Only
+          applicable when `tlog_scope_sssd` is `some`.
+      tlog_groups_sssd:
+        type: list
+        elements: str
+        default: []
+        description: >
+          List of groups whose sessions should be recorded. Only
+          applicable when `tlog_scope_sssd` is `some`.
+      tlog_exclude_users_sssd:
+        type: list
+        elements: str
+        default: []
+        description: >
+          List of users to exclude from session recording. Only
+          applicable when `tlog_scope_sssd` is `all`.
+      tlog_exclude_groups_sssd:
+        type: list
+        elements: str
+        default: []
+        description: >
+          List of groups to exclude from session recording. Only
+          applicable when `tlog_scope_sssd` is `all`.

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Assert users or groups are specified when scope is some
+  ansible.builtin.assert:
+    that:
+      - >-
+        (tlog_users_sssd | length > 0)
+        or (tlog_groups_sssd | length > 0)
+    fail_msg: >-
+      tlog_scope_sssd is 'some' but neither tlog_users_sssd nor
+      tlog_groups_sssd contains any entries - no sessions will be
+      recorded
+  when: tlog_scope_sssd == 'some'
+
+- name: Assert exclude lists are not set when scope is not all
+  ansible.builtin.assert:
+    that:
+      - tlog_exclude_users_sssd | length == 0
+      - tlog_exclude_groups_sssd | length == 0
+    fail_msg: >-
+      tlog_exclude_users_sssd and tlog_exclude_groups_sssd are only
+      applicable when tlog_scope_sssd is 'all', got
+      tlog_scope_sssd='{{ tlog_scope_sssd }}'
+  when: tlog_scope_sssd != 'all'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Validate role parameters
+  ansible.builtin.include_tasks: assert_role_vars.yml
+
 - name: Set platform/version specific variables
   include_tasks: set_vars.yml
 

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify invalid parameters are rejected
+  hosts: all
+  tasks:
+    - name: Run invalid input tests
+      block:
+        # ====================================================
+        # Section 1: Verify role works with valid defaults
+        # ====================================================
+        - name: Run role with valid defaults
+          ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+
+        # ====================================================
+        # Section 2: argument_specs validation (Ansible 2.11+)
+        # ====================================================
+        - name: Run argument specs validation tests
+          when: ansible_version.full is version('2.11', '>=')
+          block:
+            - name: Argument specs reject non-boolean tlog_use_sssd
+              block:
+                - name: Run role with non-boolean tlog_use_sssd
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+                  vars:
+                    tlog_use_sssd: not_a_bool
+              rescue:
+                - name: Mark invalid tlog_use_sssd type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_use_sssd_type_failed: true
+
+            - name: Assert invalid tlog_use_sssd type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_use_sssd_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject tlog_use_sssd when given
+                  a non-boolean value
+
+            - name: Argument specs reject invalid tlog_scope_sssd choice
+              block:
+                - name: Run role with invalid tlog_scope_sssd value
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+                  vars:
+                    tlog_scope_sssd: invalid_scope
+              rescue:
+                - name: Mark invalid tlog_scope_sssd choice rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_scope_sssd_choice_failed: true
+
+            - name: Assert invalid tlog_scope_sssd choice was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_scope_sssd_choice_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject tlog_scope_sssd value
+                  'invalid_scope'
+
+            - name: Argument specs reject non-list tlog_users_sssd
+              block:
+                - name: Run role with non-list tlog_users_sssd
+                  ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+                  vars:
+                    tlog_users_sssd: 123
+              rescue:
+                - name: Mark invalid tlog_users_sssd type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_users_sssd_type_failed: true
+
+            - name: Assert invalid tlog_users_sssd type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_users_sssd_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject tlog_users_sssd when given
+                  a non-list value
+
+        # ====================================================
+        # Section 3: assert_role_vars validation (all versions)
+        # ====================================================
+
+        - name: Assert rejects scope some with no users or groups
+          block:
+            - name: Run role with scope some and empty user/group lists
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                tlog_scope_sssd: some
+                tlog_users_sssd: []
+                tlog_groups_sssd: []
+          rescue:
+            - name: Mark scope some without users/groups rejected
+              ansible.builtin.set_fact:
+                __invalid_input_scope_some_empty_failed: true
+
+        - name: Assert scope some with no users/groups was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_scope_some_empty_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject tlog_scope_sssd 'some' when
+              neither tlog_users_sssd nor tlog_groups_sssd is specified
+
+        - name: Assert rejects exclude lists when scope is not all
+          block:
+            - name: Run role with exclude users and scope some
+              ansible.builtin.include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                tlog_scope_sssd: some
+                tlog_users_sssd:
+                  - testuser
+                tlog_exclude_users_sssd:
+                  - otheruser
+          rescue:
+            - name: Mark exclude with wrong scope rejected
+              ansible.builtin.set_fact:
+                __invalid_input_exclude_wrong_scope_failed: true
+
+        - name: Assert exclude lists with wrong scope was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_exclude_wrong_scope_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject tlog_exclude_users_sssd
+              when tlog_scope_sssd is not 'all'
+
+      always:
+        - name: Clear test facts
+          ansible.builtin.set_fact:
+            __invalid_input_use_sssd_type_failed:
+            __invalid_input_scope_sssd_choice_failed:
+            __invalid_input_users_sssd_type_failed:
+            __invalid_input_scope_some_empty_failed:
+            __invalid_input_exclude_wrong_scope_failed:
+          tags: tests::cleanup


### PR DESCRIPTION
Enhancement: Added argument spec and assert role spec validation to the tlog role. Also wrote tests for it found in tests/tests_invalid_input.

Reason: Because it is a good addition to the linux-system-roles project.

Result: Successfully added it and prepared tests for it. I used AI during this implementation.

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/postfix/issues/206 https://redhat.atlassian.net/browse/RHELMISC-16008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documented configuration options for controlling SSSD session recording, including scopes, user lists, group lists, and exclusions.

* **Bug Fixes**
  * Added validation to reject invalid parameter types, unsupported scopes, and ineffective or conflicting session-recording configurations before deployment.

* **Tests**
  * Added coverage confirming invalid inputs and incompatible scope, user, group, and exclusion settings are correctly rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->