### PR TITLE
fix: Move ini_file calls to a shared include task file

### DIFF
--- a/tasks/include_ini_file.yml
+++ b/tasks/include_ini_file.yml
@@ -1,0 +1,36 @@
+---
+# ini_file module call split by python version; args come from __tlog_ini_file_*.
+
+# python < 3.7: the latest community.general.ini_file needs python >= 3.7 to
+# import, so use the vendored ini_file_python_36 copy.
+- name: Set ini_file setting - python 3.6
+  ini_file_python_36:
+    path: "{{ __tlog_ini_file_path }}"
+    section: "{{ __tlog_ini_file_section }}"
+    option: "{{ __tlog_ini_file_option | default(omit) }}"
+    value: "{{ __tlog_ini_file_value | default(omit) }}"
+    state: "{{ __tlog_ini_file_state | default('present') }}"
+    create: "{{ __tlog_ini_file_create | default(omit) }}"
+    owner: "{{ __tlog_ini_file_owner | default(omit) }}"
+    group: "{{ __tlog_ini_file_group | default(omit) }}"
+    mode: "{{ __tlog_ini_file_mode | default(omit) }}"
+  when:
+    - not (ansible_facts['python_version'] is version('3.7', '>='))
+  notify: Handler tlog_handler restart sssd
+
+# python >= 3.7: bare name, not FQCN, because an unresolvable FQCN aborts play
+# parsing on ansible 2.9 even when skipped; resolves to community.general.ini_file.
+- name: Set ini_file setting
+  ini_file:  # noqa fqcn
+    path: "{{ __tlog_ini_file_path }}"
+    section: "{{ __tlog_ini_file_section }}"
+    option: "{{ __tlog_ini_file_option | default(omit) }}"
+    value: "{{ __tlog_ini_file_value | default(omit) }}"
+    state: "{{ __tlog_ini_file_state | default('present') }}"
+    create: "{{ __tlog_ini_file_create | default(omit) }}"
+    owner: "{{ __tlog_ini_file_owner | default(omit) }}"
+    group: "{{ __tlog_ini_file_group | default(omit) }}"
+    mode: "{{ __tlog_ini_file_mode | default(omit) }}"
+  when:
+    - ansible_facts['python_version'] is version('3.7', '>=')
+  notify: Handler tlog_handler restart sssd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,47 +20,19 @@
   when:
     - "'cockpit' in ansible_facts.packages"
 
-# On managed nodes with python < 3.7, the latest community.general.ini_file
-# fails to import ("from __future__ import annotations" requires python >=
-# 3.7), so use the dependency-free vendored ini_file_python_36 module, which
-# works on every python/ansible combination.
-- name: Configure sssd services section - python 3.6
-  ini_file_python_36:
-    path: "{{ __tlog_sssd_conf }}"
-    section: sssd
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    state: present
-    create: true
-    owner: root
-    group: root
-    mode: "0600"
-  loop:
-    - key: services
-      value: "nss, pam"
-    - key: domains
-      value: "nssfiles"
-  when:
-    - tlog_use_sssd | bool
-    - "'sssd' in ansible_facts.packages"
-    - not (ansible_facts['python_version'] is version('3.7', '>='))
-  notify: Handler tlog_handler restart sssd
-
-# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
-# ansible 2.9 even for a task skipped by "when", so the bare name is used.
-# This runs only on managed nodes with python >= 3.7, where the bare name
-# resolves to the latest collection module.
+# include_ini_file.yml selects the vendored (python < 3.7) or
+# community.general.ini_file module; values are passed as __tlog_ini_file_* vars.
 - name: Configure sssd services section
-  ini_file:  # noqa fqcn
-    path: "{{ __tlog_sssd_conf }}"
-    section: sssd
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    state: present
-    create: true
-    owner: root
-    group: root
-    mode: "0600"
+  include_tasks: include_ini_file.yml
+  vars:
+    __tlog_ini_file_path: "{{ __tlog_sssd_conf }}"
+    __tlog_ini_file_section: sssd
+    __tlog_ini_file_option: "{{ item.key }}"
+    __tlog_ini_file_value: "{{ item.value }}"
+    __tlog_ini_file_create: true
+    __tlog_ini_file_owner: root
+    __tlog_ini_file_group: root
+    __tlog_ini_file_mode: "0600"
   loop:
     - key: services
       value: "nss, pam"
@@ -69,52 +41,18 @@
   when:
     - tlog_use_sssd | bool
     - "'sssd' in ansible_facts.packages"
-    - ansible_facts['python_version'] is version('3.7', '>=')
-  notify: Handler tlog_handler restart sssd
 
-# On managed nodes with python < 3.7, the latest community.general.ini_file
-# fails to import ("from __future__ import annotations" requires python >=
-# 3.7), so use the dependency-free vendored ini_file_python_36 module, which
-# works on every python/ansible combination.
-- name: Configure sssd proxy provider domain - python 3.6
-  ini_file_python_36:
-    path: "{{ __tlog_sssd_conf }}"
-    section: domain/nssfiles
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    state: present
-    create: true
-    owner: root
-    group: root
-    mode: "0600"
-  loop:
-    - key: id_provider
-      value: proxy
-    - key: proxy_lib_name
-      value: files
-    - key: proxy_pam_target
-      value: sssd-shadowutils
-  when:
-    - tlog_use_sssd | bool
-    - "'sssd' in ansible_facts.packages"
-    - not (ansible_facts['python_version'] is version('3.7', '>='))
-  notify: Handler tlog_handler restart sssd
-
-# Bare module name (not FQCN): an unresolvable FQCN aborts play parsing on
-# ansible 2.9 even for a task skipped by "when", so the bare name is used.
-# This runs only on managed nodes with python >= 3.7, where the bare name
-# resolves to the latest collection module.
 - name: Configure sssd proxy provider domain
-  ini_file:  # noqa fqcn
-    path: "{{ __tlog_sssd_conf }}"
-    section: domain/nssfiles
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    state: present
-    create: true
-    owner: root
-    group: root
-    mode: "0600"
+  include_tasks: include_ini_file.yml
+  vars:
+    __tlog_ini_file_path: "{{ __tlog_sssd_conf }}"
+    __tlog_ini_file_section: domain/nssfiles
+    __tlog_ini_file_option: "{{ item.key }}"
+    __tlog_ini_file_value: "{{ item.value }}"
+    __tlog_ini_file_create: true
+    __tlog_ini_file_owner: root
+    __tlog_ini_file_group: root
+    __tlog_ini_file_mode: "0600"
   loop:
     - key: id_provider
       value: proxy
@@ -125,8 +63,6 @@
   when:
     - tlog_use_sssd | bool
     - "'sssd' in ansible_facts.packages"
-    - ansible_facts['python_version'] is version('3.7', '>=')
-  notify: Handler tlog_handler restart sssd
 
 - name: Configure sssd session recording config
   template:


### PR DESCRIPTION
Enhancement: Move the vendored and community.general ini_file calls into a shared include_ini_file.yml that main.yml pulls in with include_tasks, passing settings as variables.
Reason: A community.general FQCN in a statically parsed task file aborts play parsing on ansible 2.9 even when the task is skipped, which previously forced bare module names with an fqcn lint suppression.
Result: The collection module is now referenced by FQCN and only parsed at runtime, keeping ansible 2.9 support while dropping the bare-name workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized SSSD INI configuration across supported Python versions.
  - Centralized INI file updates while preserving existing configuration options and processing conditions.
  - Retained compatibility for older and newer Python environments.
  - SSSD continues to restart when INI configuration changes are applied.
  - Existing configuration behavior remains consistent across managed systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->